### PR TITLE
Trim Travis yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,1 @@
-.travis.yml:
-
-before_script:
-  - npm install
-
-script: npm test
+language: node_js


### PR DESCRIPTION
@avermeulen happy with this?

Changes:
- we don't need `npm install` since [Travis does that by default](https://docs.travis-ci.com/user/languages/javascript-with-nodejs#Travis-CI-uses-npm);
- we don't need `npm test` since [Travis does that by default](https://docs.travis-ci.com/user/languages/javascript-with-nodejs#Default-Test-Script);
- if we remove those, we do need to add `language: node_js`, though, since [Travis Lint](https://docs.travis-ci.com/user/travis-lint/) says Travis assumes Ruby by default.

Here's [an example](https://travis-ci.org/SteveBarnett/53functionsTestingTravis) of 53functions running with a trimmed `travis.yml`.
